### PR TITLE
Fix UX issues in setup wizard and improve scan logging

### DIFF
--- a/global_entry_scanner/cli.py
+++ b/global_entry_scanner/cli.py
@@ -101,6 +101,10 @@ def setup() -> None:
     if "email" in selected_channels:
         from global_entry_scanner.notifications.email import SMTP_PROVIDERS
 
+        click.echo(
+            "Supported providers: Gmail, Outlook/Hotmail, Yahoo, iCloud, Zoho, or custom SMTP.\n"
+            "Note: Most providers require an app-specific password, not your regular password."
+        )
         provider = questionary.select(
             "Email provider:",
             choices=list(SMTP_PROVIDERS.keys()),
@@ -115,6 +119,7 @@ def setup() -> None:
             smtp_host = preset_host
             smtp_port = preset_port if preset_port is not None else 587
 
+        click.echo("Tip: You can use the same email address for both 'from' and 'to'.")
         from_email = questionary.text("From email address:").ask()
         to_email = questionary.text("To email address:").ask()
         password = questionary.password(f"{password_hint}:").ask()
@@ -129,8 +134,8 @@ def setup() -> None:
     if "sms" in selected_channels:
         account_sid = questionary.text("Twilio Account SID:").ask()
         auth_token = questionary.password("Twilio Auth Token:").ask()
-        to_number = questionary.text("To phone number (e.g. +12125551234):").ask()
         from_number = questionary.text("From Twilio number (e.g. +12125550000):").ask()
+        to_number = questionary.text("To phone number (e.g. +12125551234):").ask()
         sms_cfg = SMSConfig(
             account_sid=account_sid,
             auth_token=auth_token,

--- a/global_entry_scanner/scanner.py
+++ b/global_entry_scanner/scanner.py
@@ -124,6 +124,8 @@ class Scanner:
                 results = self.check_once()
                 has_error = any(r.error for r in results)
                 new_results = [r for r in results if r.new_appointments]
+                if not new_results and not has_error:
+                    logger.info("No new appointments found.")
                 if new_results:
                     total = sum(len(r.new_appointments) for r in new_results)
                     subject = (


### PR DESCRIPTION
- Issue #3: Swap SMS setup input order to ask for 'from' number before 'to' number
- Issue #4: Log "No new appointments found." when a scan pass yields nothing new
- Issue #7: Add tip in email setup that from/to can be the same address
- Issue #8: Display supported email providers and app-password note before provider selection

https://claude.ai/code/session_01DLQnKHxL35XwoKGwYD78GZ